### PR TITLE
add sandtank load test

### DIFF
--- a/load_tests/load_test.py
+++ b/load_tests/load_test.py
@@ -346,7 +346,7 @@ def get_grid_data(hot_cold:str, calln:int) -> int:
     if hot_cold == "hot":
         wy = 2003
     else:
-        wy = 1990 + calln
+        wy = 1990 + calln % 30
     date_start = f"{wy}-01-01"
     date_end = f"{wy+1}-01-01"
     huc_id = "140100"
@@ -383,7 +383,7 @@ def get_point_data(hot_cold:str, calln:int) -> int:
     if hot_cold == "hot":
         wy = 2002
     else:
-        wy = 2003 + calln
+        wy = 2003 + calln % 20
     options = {
         "dataset": "usgs_nwis",
         "variable": "streamflow",
@@ -406,7 +406,7 @@ def get_gridded_1p_1y(hot_cold, calln):
     if hot_cold == "hot":
         wy = 1980
     else:
-        wy = 1980 + calln
+        wy = 1980 + calln % 30
     print(f"WY={wy}")
     options = {"dataset": "CW3E", "variable": "precipitation", "temporal_resolution": "hourly",
                 "grid": "conus2", "grid_point": [2191, 2097],

--- a/sandtank/README.md
+++ b/sandtank/README.md
@@ -1,0 +1,34 @@
+# Sandtank Stress Test
+
+This directory contains scripts to perform a stress test of sandtank.
+This simulate a user running sandtank by using a python module
+call playwright to simulate a user opening a web browser and clicking.
+This can be run in a script to simulate many users running sandtank
+at the same time.
+
+Previous experience shows sandtank can support 11 parallel users, but
+starts timing out after 12 simulaneous users. 
+
+Of course in a classroom with 20 students they all might have sandtank
+open, but as long as only 11 of them are actually executing sandtank
+runs at the same time it should still work. It seems like even if
+sandtank gets timeouts after 11 it does not go down.
+
+This test was executed in the old sandtank running on poudre and also the
+new sandtank running on poudre2 with the same performance and limits.
+
+## Running the Load Test
+
+Use the run_load_test.sh script to run a load test.
+
+This call simulate one parallel user running sandtank using prod sandtank.
+
+```
+bash run_load_test.sh
+```
+
+This call simulate 5 paralle users running the test version of sandtank using test sandtank.
+```
+bash run_load_test.sh 5 "https://sandtank-test.hydroframe.org"
+```
+

--- a/sandtank/check_sandtank_running.py
+++ b/sandtank/check_sandtank_running.py
@@ -1,0 +1,45 @@
+"""
+Utility to poll every 2 seconds to see if the sandtank server is still working
+"""
+import sys
+import time
+import subprocess
+
+MAX_TIME = 10
+POLLING_COUNT = 15
+POLLING_WAIT = 2
+
+def main():
+    sandtank_url = sys.argv[1] if len(sys.argv) > 1 else "https://sandtank.hydroframe.org"
+
+    for i in range(0, POLLING_COUNT):
+        print(f"Check {i+1} if sandtank is still running")
+        result = is_sandtank_running(sandtank_url)
+        if result:
+            print(result)
+            break
+        time.sleep(POLLING_WAIT)
+    
+def is_sandtank_running(sandtank_url)->str:
+    result = None
+    start_time = time.time()
+    command_result = execute_command(f"curl {sandtank_url}")
+    if not "sandtank doesn't work properly without JavaScript enabled" in command_result:
+        result = "Sandtank is not working"
+    else:
+        duration = round(time.time() - start_time,2)
+        print(f"   Check for sandtank server still responding in {duration} seconds.")
+        if duration > MAX_TIME:
+            print("   Sandtank is not responding as fast as it should, but it responded.")
+    return result
+
+
+def execute_command(command:str)->str:
+    """Execute shell command and return the stdout of executing the command."""
+    parts = command.split(" ")
+    process = subprocess.run(parts, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    result = process.stdout.decode("utf-8")
+    return result
+
+if __name__ == "__main__":
+    main()

--- a/sandtank/load_test.py
+++ b/sandtank/load_test.py
@@ -1,0 +1,54 @@
+"""
+    Run a load test of using sandtank simulate execution from a browser.
+    This runs one test, but this can be called from a script starting
+    several parallel process to simulate many users running sandtank.
+"""
+import sys
+import time
+from playwright.sync_api import Playwright, sync_playwright, expect
+
+def run(job_num:int, playwright: Playwright, sandtank_url) -> None:
+    """
+    Execute a simple scenario of using standtank calling it from a browser
+    and clicking to simulate a user runing sandtank.
+    Parameters:
+        job_num:    a job number to be printed it to know which job this is
+        playwright: An open playright session used for simulating a browser
+        sandtank_url: A url to the sandtank url to be tested.
+
+    This uses the python playwright module to simulate using a browser.
+    This allow testing of an application just as user would with clicking.
+    """
+    try:
+        browser = playwright.chromium.launch(headless=False)
+        context = browser.new_context()
+        page = context.new_page()
+        page.goto(sandtank_url)
+        page.get_by_text("0").nth(3).click()
+        page.locator("div:nth-child(2) > div:nth-child(3) > .v-btn").click()
+        page.locator("div:nth-child(2) > div:nth-child(3) > .v-btn").dblclick()
+        page.get_by_role("button", name="Run").click()
+        time.sleep(10)
+        page.locator("div:nth-child(9) > div:nth-child(3) > .v-btn").click()
+        page.locator("div:nth-child(9) > div:nth-child(3) > .v-btn").dblclick()
+        page.get_by_role("button", name="Run").click()
+        time.sleep(10)
+        print(f"Scenario with {job_num} users finished successfully.")
+    except Exception as e:
+        print(f"Exception raised in scenario #{job_num}")
+    context.close()
+    browser.close()
+
+def main():
+    """Main routine to start the load test simulating one user running sandtank."""
+    
+    job_num = sys.argv[1] if len(sys.argv) > 1 else 1
+    sandtank_url = sys.argv[2] if len(sys.argv) > 2 else "https://sandtank-test.hydroframe.org"
+    if not sandtank_url.endswith("/"):
+        sandtank_url = sandtank_url + "/"
+    with sync_playwright() as playwright:
+        run(job_num, playwright, sandtank_url)
+
+
+if __name__ == "__main__":
+    main()

--- a/sandtank/run_load_test.sh
+++ b/sandtank/run_load_test.sh
@@ -1,0 +1,21 @@
+####
+# Script to simulate a variable number of users using sandtank in parallel.
+# Each call the load_test creates a browser windows and runs a short sandtank
+# scenario. Using a larger number can simulate different size load of users
+# using sandtank at the same time.
+#
+# Usage to run 10 users in paralle
+#   bash run_load_test.sh 10
+#
+###
+
+NUM_PROCESSES=${1:-1}
+SANDTANK_URL="${2:-https://sandtank.hydroframe.org}"
+
+for i in $(seq 1 "$NUM_PROCESSES"); do
+    python load_test.py $i &
+done
+
+# After starting the jobs monitor the sandtank
+# server to see if it is still responding
+python check_sandtank_running.py SANDTANK_URL


### PR DESCRIPTION
* Added a browser based load test simulation to test sandtank being called a number of parallel users.
See the README.md in integration-testing/sandtank/README.md

* Also added mod 30 to the cold tests in integration-testing/load_tests so that more than 30 tests can be run in parallel hf_hydrodata calls using cold to use different water years for each test. If the number of tests is
bigger than 30 then it cycles around to use previous water years so "most" test using new water years
but you can run more parallel users cold.